### PR TITLE
Adjust next config to support static export

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,10 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  output: "export", // Enables "npm build" to export a static site into the /out dir
+  trailingSlash: true,
+  images: {
+    unoptimized: true,
+  }, // Disable image optimization since the Image Optimization API is not available for exported apps
+}
 
 module.exports = nextConfig


### PR DESCRIPTION
For phase 1, we are going to be serving the site as a static export. 

This PR enables static export and disables use of the Image Optimization API, which is not supported for statically exported applications. 

Please see the [Next.js docs](https://nextjs.org/docs/app/building-your-application/deploying/static-exports) for more information on static exports. 