### PR TITLE
Add generateStaticParams to dynamic artwork route 

### DIFF
--- a/src/app/artwork/[artworkId]/page.tsx
+++ b/src/app/artwork/[artworkId]/page.tsx
@@ -2,13 +2,19 @@ import { NextPage } from "next";
 import Link from "next/link";
 import { artworks } from "../../../../mock/artworks";
 
-
 interface PageProps {
   params: {
     artworkId: string;
   };
 }
 
+export async function generateStaticParams() {
+  const routes = artworks.map(artwork => ({
+    artworkId: artwork.id.toString(),
+  }));
+
+  return routes;
+}
 
 const ArtworkPage: NextPage<PageProps> = (props) => {
   const artwork = artworks.find(artwork => artwork.id === Number(props.params.artworkId));


### PR DESCRIPTION
`generateStaticParams` can be used in combination with dynamic route segments to statically generate routes at build time. 

This is needed for phase 1 since we are using SSG.

More information: https://nextjs.org/docs/app/api-reference/functions/generate-static-params