### PR TITLE
Team page styling revisions

### DIFF
--- a/components/ui/ContentContainer.tsx
+++ b/components/ui/ContentContainer.tsx
@@ -6,7 +6,7 @@ interface ContentContainerProps {
 
 const ContentContainer: React.FC<ContentContainerProps> = ({ children }) => {
   return (
-    <div className="bg-neutral-white rounded-2xl p-10 shadow-md flex flex-col md:flex-row items-center mt-10 mx-auto w-11/12 lg:w-3/5">
+    <div className="bg-neutral-white rounded-2xl p-10 shadow-md flex flex-col md:flex-row items-center mt-5 sm:mt-10 mx-auto w-11/12 lg:w-3/5">
       {children}
     </div>
   );

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -12,7 +12,7 @@ export default function page() {
       <div className="bg-secondary-blue flex flex-col sm:flex-row justify-evenly sm:gap-4 sm:px-4" >
         <ContentContainer>
           <div className="self-start">
-            <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2">Project Director</h2>
+            <h2 className="text-lg lg:text-2xl font-medium pb-1 md:pb-2">Project Director</h2>
             <ul>
               <li className="text-base lg:text-lg">Ashfaq Ishaq, Ph.D.
                 <Link href="https://www.linkedin.com/in/ashfaqishaq/" className="ml-3">
@@ -20,7 +20,7 @@ export default function page() {
                 </Link>
               </li>
             </ul>
-            <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2 pt-3">Director, Community Relations</h2>
+            <h2 className="text-lg lg:text-2xl font-medium pb-1 md:pb-2 pt-3">Director, Community Relations</h2>
             <ul>
               <li className="text-base lg:text-lg">Katty Guerami
                 <Link href="https://www.linkedin.com/in/katty-guerami-74a99014/" className="ml-3">
@@ -28,7 +28,7 @@ export default function page() {
                 </Link>
               </li>
             </ul>
-            <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2 pt-3">ICAF Paris</h2>
+            <h2 className="text-lg lg:text-2xl font-medium pb-1 md:pb-2 pt-3">ICAF Paris</h2>
             <ul>
               <li className="text-base lg:text-lg">Katherine Harold, Paris College of Art
                 <Link href="https://www.linkedin.com/in/katherine-harold-23a5a0137/" className="ml-3">
@@ -40,7 +40,7 @@ export default function page() {
         </ContentContainer>
         <ContentContainer>
           <div className="self-start">
-            <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2">Legal Advisors</h2>
+            <h2 className="text-lg lg:text-2xl font-medium pb-1 md:pb-2">Legal Advisors</h2>
             <ul>
               <li className="text-base lg:text-lg">Oroma Womeodu, Esq.</li>
               <li className="text-base lg:text-lg">Jade Monkouopm</li>
@@ -52,7 +52,7 @@ export default function page() {
       <div className="bg-secondary-blue flex flex-col sm:flex-row sm:gap-4 sm:px-4 pb-4">
         <ContentContainer>
           <div className="self-start">
-            <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2">UX/UI</h2>
+            <h2 className="text-lg lg:text-2xl font-medium pb-1 md:pb-2">UX/UI</h2>
             <ul>
               <li className="text-base lg:text-lg">Liang-Yu Su</li>
               <li className="text-base lg:text-lg">Claire Chen</li>
@@ -62,7 +62,7 @@ export default function page() {
         </ContentContainer>
         <ContentContainer>
           <div className="self-start">
-            <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2">Web Development</h2>
+            <h2 className="text-lg lg:text-2xl font-medium pb-1 md:pb-2">Web Development</h2>
             <ul>
               <li className="text-base lg:text-lg">Andrew Dame</li>
               <li className="text-base lg:text-lg">Chuck Gooley</li>
@@ -74,7 +74,7 @@ export default function page() {
         </ContentContainer>
         <ContentContainer>
           <div className="self-start">
-            <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2">Data Science</h2>
+            <h2 className="text-lg lg:text-2xl font-medium pb-1 md:pb-2">Data Science</h2>
             <ul>
               <li className="text-base lg:text-lg">Yiping Lu</li>
             </ul>

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -5,8 +5,8 @@ export default function page() {
   return (
     <div>
       {/* Title block */}
-      <div className="w-full h-40 flex items-center pl-6 bg-secondary-blue">
-        <h1 className="mb-2 mt-0 text-3xl font-medium leading-6 sm:ml-12 text-primary">Meet Our Team</h1>
+      <div className="w-full h-40 flex items-center pl-6 bg-secondary-blue -mb-10">
+        <h1 className="mb-2 mt-0 text-4xl font-semibold leading-6 sm:ml-12 text-primary">Meet Our Team</h1>
       </div>
       {/* 2 lateral content containers*/}
       <div className="bg-secondary-blue flex flex-col sm:flex-row justify-evenly gap-4 px-4 " >

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -5,11 +5,11 @@ export default function page() {
   return (
     <div>
       {/* Title block */}
-      <div className="w-full h-40 flex items-center pl-6 bg-secondary-blue -mb-10">
+      <div className="w-full h-32 flex items-center pl-6 bg-secondary-blue -mb-5 sm:-mb-10">
         <h1 className="mb-2 mt-0 text-4xl font-semibold leading-6 sm:ml-12 text-primary">Meet Our Team</h1>
       </div>
       {/* 2 lateral content containers*/}
-      <div className="bg-secondary-blue flex flex-col sm:flex-row justify-evenly gap-4 px-4 " >
+      <div className="bg-secondary-blue flex flex-col sm:flex-row justify-evenly sm:gap-4 sm:px-4" >
         <ContentContainer>
           <div className="self-start">
             <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2">Project Director</h2>
@@ -49,7 +49,7 @@ export default function page() {
         </ContentContainer>
       </div>
       {/* 3 lateral content containers*/}
-      <div className="bg-secondary-blue flex flex-col sm:flex-row justify-evenly gap-4 px-4 pb-4">
+      <div className="bg-secondary-blue flex flex-col sm:flex-row sm:gap-4 sm:px-4 pb-4">
         <ContentContainer>
           <div className="self-start">
             <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2">UX/UI</h2>
@@ -82,11 +82,11 @@ export default function page() {
         </ContentContainer>
       </div>
       {/* yellow section */}
-      <div className="w-full h-40 flex items-center pl-6 bg-main-yellow">
+      <div className="w-full h-32 flex items-center pl-6 bg-main-yellow -mb-5 sm:-mb-10">
         <h1 className="mb-2 mt-0 text-3xl font-medium leading-6 text-primary sm:ml-12 ">Advisory Committee</h1>
       </div>
       {/* content container image row NOTE: the Advisory committe links are not populated yet*/}
-      <div className="flex flex-col sm:flex-row justify-evenly gap-4 px-4 bg-main-yellow">
+      <div className="flex flex-col sm:flex-row justify-evenly gap-4 bg-main-yellow">
         <div className="basis-1/2">
           <ContentContainer>
             <div className="self-start">
@@ -107,7 +107,7 @@ export default function page() {
             </div>
           </ContentContainer>
         </div>
-        <div className="basis-1/2">
+        <div className="basis-1/2 px-4">
           <img src="/team/illustration-01.svg" alt="Three people forming a huddle"/>
         </div>
       </div>

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -11,35 +11,35 @@ export default function page() {
       {/* 2 lateral content containers*/}
       <div className="bg-secondary-blue flex flex-col sm:flex-row justify-evenly gap-4 px-4 " >
         <ContentContainer>
-          <div>
+          <div className="self-start">
             <h2 className="text-base lg:text-2xl font-medium">Project Director</h2>
             <ul>
               <li className="text-base lg:text-lg">Ashfaq Ishaq, Ph.D.
-                <Link href="https://www.linkedin.com/in/ashfaqishaq/" className="inline-block ml-3">
-                  <img src="/team/icon-linkedin.svg" alt="LinkedIn company logo" className="h-6 w-6" />
+                <Link href="https://www.linkedin.com/in/ashfaqishaq/" className="ml-3">
+                  <img src="/team/icon-linkedin.svg" alt="LinkedIn company logo" className="inline-block h-6 w-6" />
                 </Link>
               </li>
             </ul>
             <h2 className="text-base lg:text-2xl font-medium">Director, Community Relations</h2>
             <ul>
               <li className="text-base lg:text-lg">Katty Guerami
-                <Link href="https://www.linkedin.com/in/katty-guerami-74a99014/" className="inline-block ml-3">
-                  <img src="/team/icon-linkedin.svg" alt="LinkedIn company logo" className="h-6 w-6" />
+                <Link href="https://www.linkedin.com/in/katty-guerami-74a99014/" className="ml-3">
+                  <img src="/team/icon-linkedin.svg" alt="LinkedIn company logo" className="inline-block h-6 w-6" />
                 </Link>
               </li>
             </ul>
             <h2 className="text-base lg:text-2xl font-medium">ICAF Paris</h2>
             <ul>
               <li className="text-base lg:text-lg">Katherine Harold, Paris College of Art
-                <Link href="https://www.linkedin.com/in/katherine-harold-23a5a0137/" className="inline-block ml-3">
-                  <img src="/team/icon-linkedin.svg" alt="LinkedIn company logo" className="h-6 w-6" />
+                <Link href="https://www.linkedin.com/in/katherine-harold-23a5a0137/" className="ml-3">
+                  <img src="/team/icon-linkedin.svg" alt="LinkedIn company logo" className="inline-block h-6 w-6" />
                 </Link>
               </li>
             </ul>
           </div>
         </ContentContainer>
         <ContentContainer>
-          <div>
+          <div className="self-start">
             <h2 className="text-base lg:text-2xl font-medium">Legal Advisors</h2>
             <ul>
               <li className="text-base lg:text-lg">Oroma Womeodu, Esq.</li>
@@ -51,7 +51,7 @@ export default function page() {
       {/* 3 lateral content containers*/}
       <div className="bg-secondary-blue flex flex-col sm:flex-row justify-evenly gap-4 px-4 pb-4">
         <ContentContainer>
-          <div>
+          <div className="self-start">
             <h2 className="text-base lg:text-2xl font-medium">UX/UI</h2>
             <ul>
               <li className="text-base lg:text-lg">Liang-Yu Su</li>
@@ -61,7 +61,7 @@ export default function page() {
           </div>
         </ContentContainer>
         <ContentContainer>
-          <div>
+          <div className="self-start">
             <h2 className="text-base lg:text-2xl font-medium">Web Development</h2>
             <ul>
               <li className="text-base lg:text-lg">Andrew Dame</li>
@@ -73,7 +73,7 @@ export default function page() {
           </div>
         </ContentContainer>
         <ContentContainer>
-          <div>
+          <div className="self-start">
             <h2 className="text-base lg:text-2xl font-medium">Data Science</h2>
             <ul>
               <li className="text-base lg:text-lg">Yiping Lu</li>
@@ -89,18 +89,18 @@ export default function page() {
       <div className="flex flex-col sm:flex-row justify-evenly gap-4 px-4 bg-main-yellow">
         <div className="basis-1/2">
           <ContentContainer>
-            <div>
+            <div className="self-start">
               <ul>
                 <li className="text-base lg:text-lg">
                   Joe Addo
-                  <Link href="https://www.joeaddo.com/" target="_blank" className="inline-block ml-3">
-                    <img src="/team/icon-link.svg" alt="Two chains interlinked" className="h-6 w-6" />
+                  <Link href="https://www.joeaddo.com/" target="_blank" className="ml-3">
+                    <img src="/team/icon-link.svg" alt="Two chains interlinked" className="inline-block h-6 w-6" />
                   </Link>
                 </li>
                 <li className="text-base lg:text-lg">
                   Michael Shetzer
-                  <Link href="https://ceesmena.org/michael-shetzer/" target="_blank" className="inline-block ml-3">
-                    <img src="/team/icon-link.svg" alt="Two chains interlinked" className="h-6 w-6" />
+                  <Link href="https://ceesmena.org/michael-shetzer/" target="_blank" className="ml-3">
+                    <img src="/team/icon-link.svg" alt="Two chains interlinked" className="inline-block h-6 w-6" />
                   </Link>
                 </li>
               </ul>

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -12,7 +12,7 @@ export default function page() {
       <div className="bg-secondary-blue flex flex-col sm:flex-row justify-evenly gap-4 px-4 " >
         <ContentContainer>
           <div className="self-start">
-            <h2 className="text-base lg:text-2xl font-medium">Project Director</h2>
+            <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2">Project Director</h2>
             <ul>
               <li className="text-base lg:text-lg">Ashfaq Ishaq, Ph.D.
                 <Link href="https://www.linkedin.com/in/ashfaqishaq/" className="ml-3">
@@ -20,7 +20,7 @@ export default function page() {
                 </Link>
               </li>
             </ul>
-            <h2 className="text-base lg:text-2xl font-medium">Director, Community Relations</h2>
+            <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2 pt-3">Director, Community Relations</h2>
             <ul>
               <li className="text-base lg:text-lg">Katty Guerami
                 <Link href="https://www.linkedin.com/in/katty-guerami-74a99014/" className="ml-3">
@@ -28,7 +28,7 @@ export default function page() {
                 </Link>
               </li>
             </ul>
-            <h2 className="text-base lg:text-2xl font-medium">ICAF Paris</h2>
+            <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2 pt-3">ICAF Paris</h2>
             <ul>
               <li className="text-base lg:text-lg">Katherine Harold, Paris College of Art
                 <Link href="https://www.linkedin.com/in/katherine-harold-23a5a0137/" className="ml-3">
@@ -40,7 +40,7 @@ export default function page() {
         </ContentContainer>
         <ContentContainer>
           <div className="self-start">
-            <h2 className="text-base lg:text-2xl font-medium">Legal Advisors</h2>
+            <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2">Legal Advisors</h2>
             <ul>
               <li className="text-base lg:text-lg">Oroma Womeodu, Esq.</li>
               <li className="text-base lg:text-lg">Jade Monkouopm</li>
@@ -52,7 +52,7 @@ export default function page() {
       <div className="bg-secondary-blue flex flex-col sm:flex-row justify-evenly gap-4 px-4 pb-4">
         <ContentContainer>
           <div className="self-start">
-            <h2 className="text-base lg:text-2xl font-medium">UX/UI</h2>
+            <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2">UX/UI</h2>
             <ul>
               <li className="text-base lg:text-lg">Liang-Yu Su</li>
               <li className="text-base lg:text-lg">Claire Chen</li>
@@ -62,7 +62,7 @@ export default function page() {
         </ContentContainer>
         <ContentContainer>
           <div className="self-start">
-            <h2 className="text-base lg:text-2xl font-medium">Web Development</h2>
+            <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2">Web Development</h2>
             <ul>
               <li className="text-base lg:text-lg">Andrew Dame</li>
               <li className="text-base lg:text-lg">Chuck Gooley</li>
@@ -74,7 +74,7 @@ export default function page() {
         </ContentContainer>
         <ContentContainer>
           <div className="self-start">
-            <h2 className="text-base lg:text-2xl font-medium">Data Science</h2>
+            <h2 className="text-base lg:text-2xl font-medium pb-1 md:pb-2">Data Science</h2>
             <ul>
               <li className="text-base lg:text-lg">Yiping Lu</li>
             </ul>


### PR DESCRIPTION
The team page containers on Figma have less padding than other pages. I didn't want to modify the ContentContainer component too much in case it impacted the other pages. To match this look, we eventually need to adjust the ContentContainer component's padding.