### PR TITLE
fix: Add leading slash to image links to fix Firefox bug

### DIFF
--- a/components/contest/ContestBegin.tsx
+++ b/components/contest/ContestBegin.tsx
@@ -31,7 +31,7 @@ export const ContestBegin = () => {
         </div>
 
         <div className="col-span-2 z-20 sm:col-span-1">            
-          <Image src="contest_header_image.webp" width = {390} height = {271} className="sm:ml-10 lg:ml-0 w-full rounded-[225px] lg:rounded-[300px]" alt="photo" />
+          <Image src="/contest_header_image.webp" width = {390} height = {271} className="sm:ml-10 lg:ml-0 w-full rounded-[225px] lg:rounded-[300px]" alt="photo" />
         </div>
 
       </section>

--- a/components/contest/Process.tsx
+++ b/components/contest/Process.tsx
@@ -14,7 +14,7 @@ export const Process = () => {
 
 
           <div className="rounded-xl w-full h-full col-span-2 lg:col-span-1 pr-10">           
-            <Image src="laptop.webp" width = {704} height = {482} className="object-cover rounded-xl w-full h-full " alt="laptop" />
+            <Image src="/laptop.webp" width = {704} height = {482} className="object-cover rounded-xl w-full h-full " alt="laptop" />
           </div>
 
           
@@ -56,7 +56,7 @@ export const Process = () => {
             </ol>
           </article>
           <div className="rounded-xl w-full h-full col-span-2 lg:col-span-1 lg:pl-10 order-1 lg:order-2">           
-            <Image src="rules.webp" width = {704} height = {482} className="object-right object-cover rounded-xl w-full h-full" alt="rules" />
+            <Image src="/rules.webp" width = {704} height = {482} className="object-right object-cover rounded-xl w-full h-full" alt="rules" />
           </div>
 
 

--- a/components/contest/Voting.tsx
+++ b/components/contest/Voting.tsx
@@ -23,7 +23,7 @@ export const Voting = () => {
       
       <div className="grid grid-cols-2 z-20 mt-10 m-auto max-w-screen-2xl px-8 md:px-12 lg:px-16 xl:px-20">
         <div className="z-50 col-span-2 lg:col-span-1 bg-light-yellow w-full lg:w-[460px] xl:w-[636px] 2xl:w-[816px] h-fix rounded-xl">
-          <Image src="hands.webp" width = {509} height = {432} className="mx-auto w-3/4 sm:w-2/5 lg:w-1/2 xl:w-4/5 2xl:w-2/3 my-7" alt="hands" />
+          <Image src="/hands.webp" width = {509} height = {432} className="mx-auto w-3/4 sm:w-2/5 lg:w-1/2 xl:w-4/5 2xl:w-2/3 my-7" alt="hands" />
           <div className="grid grid-cols-3">
             <h2 className="text-2xl sm:text-xl lg:text-2xl lg:font-semibold col-span-3 lg:col-span-1 ml-7 sm:ml-16 lg:ml-7 xl:ml-9 2xl:ml-11">One-Vote Rule:</h2>
             <p className="mx-7 sm:mx-16 col-span-3 lg:col-span-2 mt-4 font-light text-base mb-7">Remember, your voice matters! Each participant is allowed a single vote to ensure a fair and balanced competition. Cast your vote carefully — once it's submitted, it's final!</p>

--- a/components/impact/Empowering.tsx
+++ b/components/impact/Empowering.tsx
@@ -34,8 +34,8 @@ export const Empowering = () => {
           </p>
         </div>
 
-        <Image src="heads-small.webp" alt="" width={390} height={271} className="mt-10 col-span-3 mx-auto my-auto w-full h-fit lg:hidden" />
-        <Image src="heads-large.webp" alt="" width={390} height={271} className="mt-11 col-span-3 mx-auto my-auto w-full h-fit hidden lg:block lg:order-3" />
+        <Image src="/heads-small.webp" alt="" width={390} height={271} className="mt-10 col-span-3 mx-auto my-auto w-full h-fit lg:hidden" />
+        <Image src="/heads-large.webp" alt="" width={390} height={271} className="mt-11 col-span-3 mx-auto my-auto w-full h-fit hidden lg:block lg:order-3" />
         
       </section>
 

--- a/components/impact/ImpactBegin.tsx
+++ b/components/impact/ImpactBegin.tsx
@@ -35,7 +35,7 @@ export const ImpactBegin = () => {
         </div>
 
         <div className="col-span-2 z-20 sm:col-span-1">            
-          <Image src="impact_header_image.webp" width = {390} height = {271} className="sm:ml-10 lg:ml-0 w-full rounded-[225px] lg:rounded-[300px]" alt="photo" />
+          <Image src="/impact_header_image.webp" width = {390} height = {271} className="sm:ml-10 lg:ml-0 w-full rounded-[225px] lg:rounded-[300px]" alt="photo" />
         </div>
 
       </section>


### PR DESCRIPTION
On Firefox, images sometimes don't load if they don't have a leading slash. Please add it to all image links in the future.