### PR TITLE
fix: import Image src attributes (instead of hardcoding paths) to fix Firefox bug

### DIFF
--- a/components/about/AboutHero.tsx
+++ b/components/about/AboutHero.tsx
@@ -1,5 +1,8 @@
 import Image from "next/image";
 import hashtag from "../../public/home/hashtag.svg";
+import aboutHeaderImage from "../../public/about/about_header_image.webp";
+import heroGreenBlob from "../../public/svgs/blobs/hero-green-blob.svg";
+import heroGreenBlobMini from "../../public/svgs/blobs/hero-green-blob-minitablet.svg";
 
 export const AboutHero = () => {
   return (
@@ -21,7 +24,7 @@ export const AboutHero = () => {
           </div>
         </article>
         <Image
-          src="about_header_image.webp"
+          src={aboutHeaderImage}
           alt={"View over washington monument from side of capitolium "}
           className="rounded-xl w-full h-full m-auto max-w-md md:max-w-fit md:ml-12 md:min-w-[30%]"
           // style={{boxShadow: "10px 10px 0px 8px #689576", borderRadius: "46%"}}
@@ -31,10 +34,10 @@ export const AboutHero = () => {
 
       </section>
 
-      <Image src="/svgs/blobs/hero-green-blob-minitablet.svg" alt="" width={1279} height={377} className="absolute -z-10 sm:block lg:hidden -top-32 w-full h-full" />
-      <Image src="/svgs/blobs/hero-green-blob.svg" alt="" width={1279} height={377} className="absolute -z-10 hidden lg:block xl:hidden -top-32 w-full h-full" />
-      <Image src="/svgs/blobs/hero-green-blob.svg" alt="" width={1536} height={432} className="absolute -z-10 hidden xl:block 2xl:hidden -top-32 w-full h-[1000px]" />
-      <Image src="/svgs/blobs/hero-green-blob.svg" alt="" width={1536} height={432} className="absolute -z-10 hidden 2xl:block -top-32 right-0 w-full h-full mxl:h-[1000px]" />
+      <Image src={heroGreenBlobMini} alt="" width={1279} height={377} className="absolute -z-10 sm:block lg:hidden -top-32 w-full h-full" />
+      <Image src={heroGreenBlob} alt="" width={1279} height={377} className="absolute -z-10 hidden lg:block xl:hidden -top-32 w-full h-full" />
+      <Image src={heroGreenBlob} alt="" width={1536} height={432} className="absolute -z-10 hidden xl:block 2xl:hidden -top-32 w-full h-[1000px]" />
+      <Image src={heroGreenBlob} alt="" width={1536} height={432} className="absolute -z-10 hidden 2xl:block -top-32 right-0 w-full h-full mxl:h-[1000px]" />
 
     </>
   );

--- a/components/contest/ContestBegin.tsx
+++ b/components/contest/ContestBegin.tsx
@@ -31,7 +31,7 @@ export const ContestBegin = () => {
         </div>
 
         <div className="col-span-2 z-20 sm:col-span-1">            
-          <Image src="contest_header_image.webp" width = {390} height = {271} className="sm:ml-10 lg:ml-0 w-full rounded-[225px] lg:rounded-[300px]" alt="photo" />
+          <Image src="/contest_header_image.webp" width = {390} height = {271} className="sm:ml-10 lg:ml-0 w-full rounded-[225px] lg:rounded-[300px]" alt="photo" />
         </div>
 
       </section>

--- a/components/contest/ContestBegin.tsx
+++ b/components/contest/ContestBegin.tsx
@@ -5,6 +5,7 @@ import orangeBGipad from "../../public/svgs/contest-svg/orangeBG-ipad.svg";
 import orangeBGtablet from "../../public/svgs/contest-svg/orangeBG-tablet.svg";
 import orangeBGsmall from "../../public/svgs/contest-svg/orangeBG-small.svg";
 import orangeBGlarge from "../../public/svgs/contest-svg/orangeBG-large.svg";
+import contestHeaderImage from "../../public/contest/contest_header_image.webp";
 
 export const ContestBegin = () => {
   return (
@@ -31,7 +32,7 @@ export const ContestBegin = () => {
         </div>
 
         <div className="col-span-2 z-20 sm:col-span-1">            
-          <Image src="/contest_header_image.webp" width = {390} height = {271} className="sm:ml-10 lg:ml-0 w-full rounded-[225px] lg:rounded-[300px]" alt="photo" />
+          <Image src={contestHeaderImage} width = {390} height = {271} className="sm:ml-10 lg:ml-0 w-full rounded-[225px] lg:rounded-[300px]" alt="photo" />
         </div>
 
       </section>

--- a/components/contest/Process.tsx
+++ b/components/contest/Process.tsx
@@ -14,7 +14,7 @@ export const Process = () => {
 
 
           <div className="rounded-xl w-full h-full col-span-2 lg:col-span-1 pr-10">           
-            <Image src="laptop.webp" width = {704} height = {482} className="object-cover rounded-xl w-full h-full " alt="laptop" />
+            <Image src="/laptop.webp" width = {704} height = {482} className="object-cover rounded-xl w-full h-full " alt="laptop" />
           </div>
 
           
@@ -56,7 +56,7 @@ export const Process = () => {
             </ol>
           </article>
           <div className="rounded-xl w-full h-full col-span-2 lg:col-span-1 lg:pl-10 order-1 lg:order-2">           
-            <Image src="rules.webp" width = {704} height = {482} className="object-right object-cover rounded-xl w-full h-full" alt="rules" />
+            <Image src="/rules.webp" width = {704} height = {482} className="object-right object-cover rounded-xl w-full h-full" alt="rules" />
           </div>
 
 

--- a/components/contest/Process.tsx
+++ b/components/contest/Process.tsx
@@ -1,5 +1,7 @@
 import Image from "next/image";
 import {AnimatedScribble} from "../../components/common/decorations/AnimatedScribble";
+import laptop from "../../public/contest/laptop.webp";
+import rules from "../../public/contest/rules.webp";
 
 export const Process = () => {
   return (
@@ -14,7 +16,7 @@ export const Process = () => {
 
 
           <div className="rounded-xl w-full h-full col-span-2 lg:col-span-1 pr-10">           
-            <Image src="/laptop.webp" width = {704} height = {482} className="object-cover rounded-xl w-full h-full " alt="laptop" />
+            <Image src={laptop} width = {704} height = {482} className="object-cover rounded-xl w-full h-full " alt="laptop" />
           </div>
 
           
@@ -56,7 +58,7 @@ export const Process = () => {
             </ol>
           </article>
           <div className="rounded-xl w-full h-full col-span-2 lg:col-span-1 lg:pl-10 order-1 lg:order-2">           
-            <Image src="/rules.webp" width = {704} height = {482} className="object-right object-cover rounded-xl w-full h-full" alt="rules" />
+            <Image src={rules} width = {704} height = {482} className="object-right object-cover rounded-xl w-full h-full" alt="rules" />
           </div>
 
 

--- a/components/contest/Voting.tsx
+++ b/components/contest/Voting.tsx
@@ -5,6 +5,7 @@ import { VoteIcon } from "../../public/svgs/contest-svg/VoteIcon";
 import { ThreeDot } from "../../public/svgs/contest-svg/ThreeDot";
 import { ThreePerson } from "../../public/svgs/contest-svg/ThreePerson";
 import { ThreeMedal } from "../../public/svgs/contest-svg/ThreeMedal";
+import hands from "../../public/contest/hands.webp";
 
 export const Voting = () => {
   return (
@@ -23,7 +24,7 @@ export const Voting = () => {
       
       <div className="grid grid-cols-2 z-20 mt-10 m-auto max-w-screen-2xl px-8 md:px-12 lg:px-16 xl:px-20">
         <div className="z-50 col-span-2 lg:col-span-1 bg-light-yellow w-full lg:w-[460px] xl:w-[636px] 2xl:w-[816px] h-fix rounded-xl">
-          <Image src="/hands.webp" width = {509} height = {432} className="mx-auto w-3/4 sm:w-2/5 lg:w-1/2 xl:w-4/5 2xl:w-2/3 my-7" alt="hands" />
+          <Image src={hands} width = {509} height = {432} className="mx-auto w-3/4 sm:w-2/5 lg:w-1/2 xl:w-4/5 2xl:w-2/3 my-7" alt="hands" />
           <div className="grid grid-cols-3">
             <h2 className="text-2xl sm:text-xl lg:text-2xl lg:font-semibold col-span-3 lg:col-span-1 ml-7 sm:ml-16 lg:ml-7 xl:ml-9 2xl:ml-11">One-Vote Rule:</h2>
             <p className="mx-7 sm:mx-16 col-span-3 lg:col-span-2 mt-4 font-light text-base mb-7">Remember, your voice matters! Each participant is allowed a single vote to ensure a fair and balanced competition. Cast your vote carefully — once it's submitted, it's final!</p>

--- a/components/contest/Voting.tsx
+++ b/components/contest/Voting.tsx
@@ -23,7 +23,7 @@ export const Voting = () => {
       
       <div className="grid grid-cols-2 z-20 mt-10 m-auto max-w-screen-2xl px-8 md:px-12 lg:px-16 xl:px-20">
         <div className="z-50 col-span-2 lg:col-span-1 bg-light-yellow w-full lg:w-[460px] xl:w-[636px] 2xl:w-[816px] h-fix rounded-xl">
-          <Image src="hands.webp" width = {509} height = {432} className="mx-auto w-3/4 sm:w-2/5 lg:w-1/2 xl:w-4/5 2xl:w-2/3 my-7" alt="hands" />
+          <Image src="/hands.webp" width = {509} height = {432} className="mx-auto w-3/4 sm:w-2/5 lg:w-1/2 xl:w-4/5 2xl:w-2/3 my-7" alt="hands" />
           <div className="grid grid-cols-3">
             <h2 className="text-2xl sm:text-xl lg:text-2xl lg:font-semibold col-span-3 lg:col-span-1 ml-7 sm:ml-16 lg:ml-7 xl:ml-9 2xl:ml-11">One-Vote Rule:</h2>
             <p className="mx-7 sm:mx-16 col-span-3 lg:col-span-2 mt-4 font-light text-base mb-7">Remember, your voice matters! Each participant is allowed a single vote to ensure a fair and balanced competition. Cast your vote carefully — once it's submitted, it's final!</p>

--- a/components/impact/Empowering.tsx
+++ b/components/impact/Empowering.tsx
@@ -34,8 +34,8 @@ export const Empowering = () => {
           </p>
         </div>
 
-        <Image src="heads-small.webp" alt="" width={390} height={271} className="mt-10 col-span-3 mx-auto my-auto w-full h-fit lg:hidden" />
-        <Image src="heads-large.webp" alt="" width={390} height={271} className="mt-11 col-span-3 mx-auto my-auto w-full h-fit hidden lg:block lg:order-3" />
+        <Image src="/heads-small.webp" alt="" width={390} height={271} className="mt-10 col-span-3 mx-auto my-auto w-full h-fit lg:hidden" />
+        <Image src="/heads-large.webp" alt="" width={390} height={271} className="mt-11 col-span-3 mx-auto my-auto w-full h-fit hidden lg:block lg:order-3" />
         
       </section>
 

--- a/components/impact/Empowering.tsx
+++ b/components/impact/Empowering.tsx
@@ -6,6 +6,9 @@ import yellowBGsmall from "../../public/svgs/impact-svg/yellowBG-small.svg";
 import yellowBGlarge from "../../public/svgs/impact-svg/yellowBG-large.svg";
 import yellowTiny from "../../public/svgs/impact-svg/yellowBlobTiny.svg";
 import icafLogo from "../../public/svgs/Icaf-logo.svg";
+import headsLarge from "../../public/impact/heads-large.webp";
+import headsSmall from "../../public/impact/heads-small.webp";
+import colorfulScribble from "../../public/svgs/colorful-scribble.svg";
 
 export const Empowering = () => {
   return (
@@ -25,7 +28,7 @@ export const Empowering = () => {
           <h2 className="text-3xl font-normal ">
             Empowering the Next <span className="inline-block">
               Generation
-              <Image src="/svgs/colorful-scribble.svg" alt="" width={250} height={20} />
+              <Image src={colorfulScribble} alt="" width={250} height={20} />
             </span>
             
           </h2>
@@ -34,8 +37,8 @@ export const Empowering = () => {
           </p>
         </div>
 
-        <Image src="/heads-small.webp" alt="" width={390} height={271} className="mt-10 col-span-3 mx-auto my-auto w-full h-fit lg:hidden" />
-        <Image src="/heads-large.webp" alt="" width={390} height={271} className="mt-11 col-span-3 mx-auto my-auto w-full h-fit hidden lg:block lg:order-3" />
+        <Image src={headsSmall} alt="" width={390} height={271} className="mt-10 col-span-3 mx-auto my-auto w-full h-fit lg:hidden" />
+        <Image src={headsLarge} alt="" width={390} height={271} className="mt-11 col-span-3 mx-auto my-auto w-full h-fit hidden lg:block lg:order-3" />
         
       </section>
 

--- a/components/impact/ImpactBegin.tsx
+++ b/components/impact/ImpactBegin.tsx
@@ -5,6 +5,7 @@ import pinkBGipad from "../../public/svgs/impact-svg/pinkBG-ipad.svg";
 import pinkBGtablet from "../../public/svgs/impact-svg/pinkBG-tablet.svg";
 import pinkBGsmall from "../../public/svgs/impact-svg/pinkBG-small.svg";
 import pinkBGlarge from "../../public/svgs/impact-svg/pinkBG-large.svg";
+import impactHeaderImage from "../../public/impact/impact_header_image.webp";
 
 export const ImpactBegin = () => {
   return (
@@ -35,7 +36,7 @@ export const ImpactBegin = () => {
         </div>
 
         <div className="col-span-2 z-20 sm:col-span-1">            
-          <Image src="/impact_header_image.webp" width = {390} height = {271} className="sm:ml-10 lg:ml-0 w-full rounded-[225px] lg:rounded-[300px]" alt="photo" />
+          <Image src={impactHeaderImage} width = {390} height = {271} className="sm:ml-10 lg:ml-0 w-full rounded-[225px] lg:rounded-[300px]" alt="photo" />
         </div>
 
       </section>

--- a/components/impact/ImpactBegin.tsx
+++ b/components/impact/ImpactBegin.tsx
@@ -35,7 +35,7 @@ export const ImpactBegin = () => {
         </div>
 
         <div className="col-span-2 z-20 sm:col-span-1">            
-          <Image src="impact_header_image.webp" width = {390} height = {271} className="sm:ml-10 lg:ml-0 w-full rounded-[225px] lg:rounded-[300px]" alt="photo" />
+          <Image src="/impact_header_image.webp" width = {390} height = {271} className="sm:ml-10 lg:ml-0 w-full rounded-[225px] lg:rounded-[300px]" alt="photo" />
         </div>
 
       </section>


### PR DESCRIPTION
On Firefox, when a page is navigated to via the header, some images never load. I thought this was due to a missing slash at the start of the src= address, but this does not fix the problem. Changing the images to have a src of an image imported at the top of the page fixes the problem for all browsers.

I see that many .svg images are still hardcoded without being imported at the top of file. Unsure whether this will cause problems.