### PR TITLE
Add prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,31 +1,13 @@
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
-  "plugins": [
-    "@typescript-eslint"
-  ],
-  "extends": [
-    "next/core-web-vitals",
-    "plugin:@typescript-eslint/recommended"
-  ],
+  "plugins": ["@typescript-eslint"],
+  "extends": ["next/core-web-vitals", "plugin:@typescript-eslint/recommended"],
   "rules": {
-    "indent": [
-      "error",
-      2
-    ],
     "linebreak-style": "off",
-    "quotes": [
-      "error",
-      "double"
-    ],
-    "semi": [
-      "error",
-      "always"
-    ],
-    "jsx-quotes": [
-      "error", 
-      "prefer-double"
-    ],
+    "quotes": ["error", "double"],
+    "semi": ["error", "always"],
+    "jsx-quotes": ["error", "prefer-double"],
     "react/no-unescaped-entities": "off",
     "jsx-a11y/alt-text": "error"
   }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-# npm run lint
-
+npm run lint
 npm run format $(git diff --name-only --diff-filter=d HEAD | xargs)
 git add $(git diff --name-only --diff-filter=d HEAD | xargs)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,5 +2,6 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 # npm run lint
-npm run format $(git diff --name-only --diff-filter=d HEAD | xargs)
 
+npm run format $(git diff --name-only --diff-filter=d HEAD | xargs)
+git add $(git diff --name-only --diff-filter=d HEAD | xargs)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint
+# npm run lint
+npm run format $(git diff --name-only --diff-filter=d HEAD | xargs)
+

--- a/components/common/form_inputs/TextInput.tsx
+++ b/components/common/form_inputs/TextInput.tsx
@@ -15,7 +15,7 @@ interface IProps {
   required?: boolean
 }
 export const TextInput = ({className, labelText, id, placeholder, inputType, error, touched, value, required = true}: IProps) => {
-
+// test change to format staged file
   return (
     <div className={`${className} my-1 flex flex-col`} >
       <InputLabel

--- a/components/common/form_inputs/TextInput.tsx
+++ b/components/common/form_inputs/TextInput.tsx
@@ -1,53 +1,71 @@
 import React from "react";
-import { Field} from "formik";
-import {InputLabel} from "./InputLabel";
-import {ErrorSuccessPopUp} from "./ErrorSuccessPopUp";
+import { Field } from "formik";
+import { InputLabel } from "./InputLabel";
+import { ErrorSuccessPopUp } from "./ErrorSuccessPopUp";
 
 interface IProps {
-  className?: string
-  labelText: string
-  id: string
-  placeholder?: string
-  inputType?: string
-  error: string | undefined
-  touched: boolean | undefined
-  value: string | undefined
-  required?: boolean
+  className?: string;
+  labelText: string;
+  id: string;
+  placeholder?: string;
+  inputType?: string;
+  error: string | undefined;
+  touched: boolean | undefined;
+  value: string | undefined;
+  required?: boolean;
 }
-export const TextInput = ({className, labelText, id, placeholder, inputType, error, touched, value, required = true}: IProps) => {
-// test change to format staged file
+export const TextInput = ({
+  className,
+  labelText,
+  id,
+  placeholder,
+  inputType,
+  error,
+  touched,
+  value,
+  required = true,
+}: IProps) => {
+  // test change to format staged file
   return (
-    <div className={`${className} my-1 flex flex-col`} >
+    <div className={`${className} my-1 flex flex-col`}>
       <InputLabel
         className={`font-semibold ${
-          required && error && touched ? "text-accent-red"
-            :
-            required &&!error && touched && value ?  "text-accent-green"
-              :
-              ""
+          required && error && touched
+            ? "text-accent-red"
+            : required && !error && touched && value
+              ? "text-accent-green"
+              : ""
         }`}
-        labelText={labelText} htmlFor={id} error={error} touched={touched}
+        labelText={labelText}
+        htmlFor={id}
+        error={error}
+        touched={touched}
       />
       <Field
         className={`
           my-2 p-3 border-1 rounded-lg 
           ${
-    required && error && touched ? "border-accent-red placeholder:text-accent-red"  
-      :
-      required &&!error && touched && value ? "border-accent-green" 
-        :
-        "border-black"
-    }
+            required && error && touched
+              ? "border-accent-red placeholder:text-accent-red"
+              : required && !error && touched && value
+                ? "border-accent-green"
+                : "border-black"
+          }
 
         `}
-        placeholder={ placeholder || "Start typing here..."}
-        type={inputType || "text" }
+        placeholder={placeholder || "Start typing here..."}
+        type={inputType || "text"}
         id={id}
         name={id}
-      >
-      </Field>
+      ></Field>
 
-      <ErrorSuccessPopUp required={required} id={id} error={error} touched={touched} value={value} />
+      <ErrorSuccessPopUp
+        required={required}
+        id={id}
+        error={error}
+        touched={touched}
+        value={value}
+      />
     </div>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "autoprefixer": "^10.4.16",
         "husky": "^8.0.3",
         "postcss": "^8.4.24",
+        "prettier": "^3.2.5",
         "tailwindcss": "^3.3.3",
         "typescript": "5.3.3"
       }
@@ -4420,6 +4421,21 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "format": "prettier --write --ignore-unknown"
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",
@@ -44,6 +45,7 @@
     "autoprefixer": "^10.4.16",
     "husky": "^8.0.3",
     "postcss": "^8.4.24",
+    "prettier": "^3.2.5",
     "tailwindcss": "^3.3.3",
     "typescript": "5.3.3"
   }


### PR DESCRIPTION
This PR does a few things: 
1. Installs `prettier` as a dev dependency for formatting our files.
2. Adds a pre-commit script to format staged files.
3. Removes the `indent` rule from eslint, since prettier will take care of this now and we don't want them to conflict.
4. Makes a change to `TextInput` to test that this works.
5. Formats all the files as described in (2).

In a follow-up PR, we should run `npm run format .` to format all the files in the project for consistency.